### PR TITLE
[DVT-121] add github actions build workflow

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
 
-  binary_linux_amd64:
+  build_linux_amd64:
     runs-on: ubuntu-latest
     steps:
          - uses: actions/checkout@v2
@@ -14,32 +14,31 @@ jobs:
             yarn install
             yarn run build:www
             tar czf avail-apps-linux-amd64.tar.gz /home/runner/work/avail-apps/avail-apps/packages/apps/build
-            mkdir -p /tmp/build_extract
-            tar -xvf avail-apps-linux-amd64.tar.gz --directory /tmp/build_extract
          - uses: actions/upload-artifact@v2
            with:
              name: avail-apps-linux-amd64-build
              path: /home/runner/work/avail-apps/avail-apps/avail-apps-linux-amd64.tar.gz
 
-  # can extend binary publish 'needs' to include more releases i.e. arm64 in future
-  # binary_publish:
-  #   needs: [binary_linux_amd64]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #        - uses: actions/download-artifact@v2
-  #          with:
-  #            name: avail-light-linux-amd64-binary
-  #        - name: Prepare
-  #          id: prepare
-  #          run: |
-  #              TAG=${GITHUB_REF#refs/tags/}
-  #              echo ::set-output name=tag_name::${TAG}
-  #        - name: publish binaries
-  #          uses: svenstaro/upload-release-action@v2
-  #          with:
-  #            repo_token: ${{ secrets.PAT_TOKEN }}
-  #            file: /home/runner/work/avail-light/avail-light/avail-light*
-  #            release_name: ${{ steps.prepare.outputs.tag_name }}
-  #            tag: ${{ steps.prepare.outputs.tag_name }}
-  #            overwrite: true
-  #            file_glob: true
+  # can extend builds publish 'needs' to include more releases i.e. arm64 in future
+  build_publish:
+    needs: [build_linux_amd64]
+    runs-on: ubuntu-latest
+    steps:
+         - uses: actions/download-artifact@v2
+           with:
+             name: avail-apps-linux-amd64-build
+         - name: Prepare
+           id: prepare
+           run: |
+               # TAG=${GITHUB_REF#refs/tags/}
+               # echo ::set-output name=tag_name::${TAG}
+               tar -xvf avail-apps-linux-amd64-build
+         # - name: publish builds
+         #   uses: svenstaro/upload-release-action@v2
+         #   with:
+         #     repo_token: ${{ secrets.PAT_TOKEN }}
+         #     file: /home/runner/work/avail-light/avail-light/avail-light*
+         #     release_name: ${{ steps.prepare.outputs.tag_name }}
+         #     tag: ${{ steps.prepare.outputs.tag_name }}
+         #     overwrite: true
+         #     file_glob: true

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -1,0 +1,47 @@
+name: Releaser
+on:
+  push:
+
+jobs:
+
+  binary_linux_amd64:
+    runs-on: ubuntu-latest
+    steps:
+         - uses: actions/checkout@v2
+         - name: build avail explorer via yarn
+           shell: bash
+           run: |
+            yarn install
+            echo "PWD"
+            pwd
+            yarn run build:www
+            echo "LS"
+            ls /home/runner/work/avail-apps/avail-apps/packages/apps/
+            tar czf avail-apps-linux-amd64.tar.gz ls /home/runner/work/avail-apps/avail-apps/packages/apps/build
+         - uses: actions/upload-artifact@v2
+           with:
+             name: avail-apps-linux-amd64-build
+             path: /home/runner/work/avail-apps/avail-apps/avail-apps-linux-amd64.tar.gz
+
+  # can extend binary publish 'needs' to include more releases i.e. arm64 in future
+  # binary_publish:
+  #   needs: [binary_linux_amd64]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #        - uses: actions/download-artifact@v2
+  #          with:
+  #            name: avail-light-linux-amd64-binary
+  #        - name: Prepare
+  #          id: prepare
+  #          run: |
+  #              TAG=${GITHUB_REF#refs/tags/}
+  #              echo ::set-output name=tag_name::${TAG}
+  #        - name: publish binaries
+  #          uses: svenstaro/upload-release-action@v2
+  #          with:
+  #            repo_token: ${{ secrets.PAT_TOKEN }}
+  #            file: /home/runner/work/avail-light/avail-light/avail-light*
+  #            release_name: ${{ steps.prepare.outputs.tag_name }}
+  #            tag: ${{ steps.prepare.outputs.tag_name }}
+  #            overwrite: true
+  #            file_glob: true

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
 
-  build_linux_amd64:
+  build_explorer:
     runs-on: ubuntu-latest
     steps:
          - uses: actions/checkout@v2
@@ -26,7 +26,7 @@ jobs:
              path: /home/runner/work/avail-apps/avail-apps/packages/apps/avail-explorer.tar.gz
 
   build_publish:
-    needs: [build_linux_amd64]
+    needs: [build_explorer]
     runs-on: ubuntu-latest
     steps:
          - uses: actions/download-artifact@v2

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -32,7 +32,8 @@ jobs:
            run: |
                # TAG=${GITHUB_REF#refs/tags/}
                # echo ::set-output name=tag_name::${TAG}
-               tar -xvf avail-apps-linux-amd64-build
+               ls /home/runner/work/avail-light/avail-light/
+               tar -xvf /home/runner/work/avail-light/avail-light/avail-apps-linux-amd64-build
          # - name: publish builds
          #   uses: svenstaro/upload-release-action@v2
          #   with:

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -12,12 +12,9 @@ jobs:
            shell: bash
            run: |
             yarn install
-            echo "PWD"
-            pwd
             yarn run build:www
-            echo "LS"
-            ls /home/runner/work/avail-apps/avail-apps/packages/apps/
-            tar czf avail-apps-linux-amd64.tar.gz ls /home/runner/work/avail-apps/avail-apps/packages/apps/build
+            tar czf avail-apps-linux-amd64.tar.gz /home/runner/work/avail-apps/avail-apps/packages/apps/build
+            tar -xvf avail-apps-linux-amd64.tar.gz
          - uses: actions/upload-artifact@v2
            with:
              name: avail-apps-linux-amd64-build

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -14,7 +14,8 @@ jobs:
             yarn install
             yarn run build:www
             tar czf avail-apps-linux-amd64.tar.gz /home/runner/work/avail-apps/avail-apps/packages/apps/build
-            tar -xvf avail-apps-linux-amd64.tar.gz
+            mkdir -p /tmp/build_extract
+            tar -xvf avail-apps-linux-amd64.tar.gz --directory /tmp/build_extract
          - uses: actions/upload-artifact@v2
            with:
              name: avail-apps-linux-amd64-build

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -13,11 +13,13 @@ jobs:
            run: |
             yarn install
             yarn run build:www
-            tar czf avail-apps-linux-amd64.tar.gz /home/runner/work/avail-apps/avail-apps/packages/apps/build
+            pushd /home/runner/work/avail-apps/avail-apps/packages/apps/
+            tar czf avail-apps-linux-amd64.tar.gz build/
+            popd
          - uses: actions/upload-artifact@v2
            with:
              name: avail-apps-linux-amd64-build
-             path: /home/runner/work/avail-apps/avail-apps/avail-apps-linux-amd64.tar.gz
+             path: /home/runner/work/avail-apps/avail-apps/packages/apps/avail-apps-linux-amd64.tar.gz
              
   build_linux_aarch64:
     runs-on: ubuntu-latest
@@ -28,11 +30,12 @@ jobs:
            run: |
             npm_config_target_arch=arm64 npm_config_target_platform=linux npm_config_target_libc=glibc yarn install
             yarn run build:www
-            tar czf avail-apps-linux-aarch64.tar.gz /home/runner/work/avail-apps/avail-apps/packages/apps/build
+            pushd /home/runner/work/avail-apps/avail-apps/packages/apps/
+            tar czf avail-apps-linux-aarch64.tar.gz build/
          - uses: actions/upload-artifact@v2
            with:
              name: avail-apps-linux-aarch64-build
-             path: /home/runner/work/avail-apps/avail-apps/avail-apps-linux-aarch64.tar.gz
+             path: /home/runner/work/avail-apps/avail-apps/packages/apps/avail-apps-linux-aarch64.tar.gz
 
   # can extend builds publish 'needs' to include more releases i.e. arm64 in future
   build_publish:

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -1,11 +1,11 @@
 name: Releaser
 on:
   push:
-    # branches-ignore:
-    #   - '**'
-    # tags:
-    #   - 'v*.*.*'
-    #   - 'v*.*.*-*'
+    branches-ignore:
+      - '**'
+    tags:
+      - 'v*.*.*'
+      - 'v*.*.*-*'
 
 jobs:
 
@@ -55,18 +55,14 @@ jobs:
          - name: Prepare
            id: prepare
            run: |
-               # TAG=${GITHUB_REF#refs/tags/}
-               # echo ::set-output name=tag_name::${TAG}
-               echo "MAIN"
-               ls
-               echo "APPS"
-               ls /home/runner/work/avail-apps/avail-apps/
-         # - name: publish builds
-         #   uses: svenstaro/upload-release-action@v2
-         #   with:
-         #     repo_token: ${{ secrets.PAT_TOKEN }}
-         #     file: /home/runner/work/avail-apps/avail-apps/avail-apps*
-         #     release_name: ${{ steps.prepare.outputs.tag_name }}
-         #     tag: ${{ steps.prepare.outputs.tag_name }}
-         #     overwrite: true
-         #     file_glob: true
+               TAG=${GITHUB_REF#refs/tags/}
+               echo ::set-output name=tag_name::${TAG}
+         - name: publish builds
+           uses: svenstaro/upload-release-action@v2
+           with:
+             repo_token: ${{ secrets.PAT_TOKEN }}
+             file: /home/runner/work/avail-apps/avail-apps/avail-apps*
+             release_name: ${{ steps.prepare.outputs.tag_name }}
+             tag: ${{ steps.prepare.outputs.tag_name }}
+             overwrite: true
+             file_glob: true

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -32,8 +32,8 @@ jobs:
            run: |
                # TAG=${GITHUB_REF#refs/tags/}
                # echo ::set-output name=tag_name::${TAG}
-               ls /home/runner/work/avail-light/avail-light/
-               tar -xvf /home/runner/work/avail-light/avail-light/avail-apps-linux-amd64-build
+               ls /home/runner/work/avail-apps/avail-apps/
+               tar -xvf /home/runner/work/avail-apps/avail-apps/avail-apps-linux-amd64-build
          # - name: publish builds
          #   uses: svenstaro/upload-release-action@v2
          #   with:

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -1,11 +1,11 @@
 name: Releaser
 on:
   push:
-    branches-ignore:
-      - '**'
-    tags:
-      - 'v*.*.*'
-      - 'v*.*.*-*'
+    # branches-ignore:
+    #   - '**'
+    # tags:
+    #   - 'v*.*.*'
+    #   - 'v*.*.*-*'
 
 jobs:
 
@@ -55,14 +55,18 @@ jobs:
          - name: Prepare
            id: prepare
            run: |
-               TAG=${GITHUB_REF#refs/tags/}
-               echo ::set-output name=tag_name::${TAG}
-         - name: publish builds
-           uses: svenstaro/upload-release-action@v2
-           with:
-             repo_token: ${{ secrets.PAT_TOKEN }}
-             file: /home/runner/work/avail-apps/avail-apps/avail-apps*
-             release_name: ${{ steps.prepare.outputs.tag_name }}
-             tag: ${{ steps.prepare.outputs.tag_name }}
-             overwrite: true
-             file_glob: true
+               # TAG=${GITHUB_REF#refs/tags/}
+               # echo ::set-output name=tag_name::${TAG}
+               echo "MAIN"
+               ls
+               echo "APPS"
+               ls /home/runner/work/avail-apps/avail-apps/
+         # - name: publish builds
+         #   uses: svenstaro/upload-release-action@v2
+         #   with:
+         #     repo_token: ${{ secrets.PAT_TOKEN }}
+         #     file: /home/runner/work/avail-apps/avail-apps/avail-apps*
+         #     release_name: ${{ steps.prepare.outputs.tag_name }}
+         #     tag: ${{ steps.prepare.outputs.tag_name }}
+         #     overwrite: true
+         #     file_glob: true

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -55,8 +55,8 @@ jobs:
          - name: Prepare
            id: prepare
            run: |
-               # TAG=${GITHUB_REF#refs/tags/}
-               # echo ::set-output name=tag_name::${TAG}
+               TAG=${GITHUB_REF#refs/tags/}
+               echo ::set-output name=tag_name::${TAG}
          - name: publish builds
            uses: svenstaro/upload-release-action@v2
            with:

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -1,6 +1,11 @@
 name: Releaser
 on:
   push:
+    branches-ignore:
+      - '**'
+    tags:
+      - 'v*.*.*'
+      - 'v*.*.*-*'
 
 jobs:
 
@@ -37,7 +42,6 @@ jobs:
              name: avail-apps-linux-aarch64-build
              path: /home/runner/work/avail-apps/avail-apps/packages/apps/avail-apps-linux-aarch64.tar.gz
 
-  # can extend builds publish 'needs' to include more releases i.e. arm64 in future
   build_publish:
     needs: [build_linux_amd64, build_linux_aarch64]
     runs-on: ubuntu-latest
@@ -53,14 +57,12 @@ jobs:
            run: |
                # TAG=${GITHUB_REF#refs/tags/}
                # echo ::set-output name=tag_name::${TAG}
-               tar -xvf /home/runner/work/avail-apps/avail-apps/avail-apps-linux-amd64.tar.gz
-               tar -xvf /home/runner/work/avail-apps/avail-apps/avail-apps-linux-aarch64.tar.gz
-         # - name: publish builds
-         #   uses: svenstaro/upload-release-action@v2
-         #   with:
-         #     repo_token: ${{ secrets.PAT_TOKEN }}
-         #     file: /home/runner/work/avail-light/avail-light/avail-light*
-         #     release_name: ${{ steps.prepare.outputs.tag_name }}
-         #     tag: ${{ steps.prepare.outputs.tag_name }}
-         #     overwrite: true
-         #     file_glob: true
+         - name: publish builds
+           uses: svenstaro/upload-release-action@v2
+           with:
+             repo_token: ${{ secrets.PAT_TOKEN }}
+             file: /home/runner/work/avail-light/avail-light/avail-apps*
+             release_name: ${{ steps.prepare.outputs.tag_name }}
+             tag: ${{ steps.prepare.outputs.tag_name }}
+             overwrite: true
+             file_glob: true

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -18,22 +18,40 @@ jobs:
            with:
              name: avail-apps-linux-amd64-build
              path: /home/runner/work/avail-apps/avail-apps/avail-apps-linux-amd64.tar.gz
+             
+  build_linux_aarch64:
+    runs-on: ubuntu-latest
+    steps:
+         - uses: actions/checkout@v2
+         - name: build avail explorer via yarn
+           shell: bash
+           run: |
+            npm_config_target_arch=arm64 npm_config_target_platform=linux npm_config_target_libc=glibc yarn install
+            yarn run build:www
+            tar czf avail-apps-linux-aarch64.tar.gz /home/runner/work/avail-apps/avail-apps/packages/apps/build
+         - uses: actions/upload-artifact@v2
+           with:
+             name: avail-apps-linux-aarch64-build
+             path: /home/runner/work/avail-apps/avail-apps/avail-apps-linux-aarch64.tar.gz
 
   # can extend builds publish 'needs' to include more releases i.e. arm64 in future
   build_publish:
-    needs: [build_linux_amd64]
+    needs: [build_linux_amd64, build_linux_aarch64]
     runs-on: ubuntu-latest
     steps:
          - uses: actions/download-artifact@v2
            with:
              name: avail-apps-linux-amd64-build
+         - uses: actions/download-artifact@v2
+           with:
+             name: avail-apps-linux-aarch64-build
          - name: Prepare
            id: prepare
            run: |
                # TAG=${GITHUB_REF#refs/tags/}
                # echo ::set-output name=tag_name::${TAG}
-               ls /home/runner/work/avail-apps/avail-apps/
-               tar -xvf /home/runner/work/avail-apps/avail-apps/avail-apps-linux-amd64-build
+               tar -xvf /home/runner/work/avail-apps/avail-apps/avail-apps-linux-amd64.tar.gz
+               tar -xvf /home/runner/work/avail-apps/avail-apps/avail-apps-linux-aarch64.tar.gz
          # - name: publish builds
          #   uses: svenstaro/upload-release-action@v2
          #   with:

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -4,8 +4,7 @@ on:
     branches-ignore:
       - '**'
     tags:
-      - 'v*.*.*'
-      - 'v*.*.*-*'
+      - '*'
 
 jobs:
 
@@ -19,39 +18,20 @@ jobs:
             yarn install
             yarn run build:www
             pushd /home/runner/work/avail-apps/avail-apps/packages/apps/
-            tar czf avail-apps-linux-amd64.tar.gz build/
+            tar czf avail-explorer.tar.gz build/
             popd
          - uses: actions/upload-artifact@v2
            with:
-             name: avail-apps-linux-amd64-build
-             path: /home/runner/work/avail-apps/avail-apps/packages/apps/avail-apps-linux-amd64.tar.gz
-             
-  build_linux_aarch64:
-    runs-on: ubuntu-latest
-    steps:
-         - uses: actions/checkout@v2
-         - name: build avail explorer via yarn
-           shell: bash
-           run: |
-            npm_config_target_arch=arm64 npm_config_target_platform=linux npm_config_target_libc=glibc yarn install
-            yarn run build:www
-            pushd /home/runner/work/avail-apps/avail-apps/packages/apps/
-            tar czf avail-apps-linux-aarch64.tar.gz build/
-         - uses: actions/upload-artifact@v2
-           with:
-             name: avail-apps-linux-aarch64-build
-             path: /home/runner/work/avail-apps/avail-apps/packages/apps/avail-apps-linux-aarch64.tar.gz
+             name: avail-explorer
+             path: /home/runner/work/avail-apps/avail-apps/packages/apps/avail-explorer.tar.gz
 
   build_publish:
-    needs: [build_linux_amd64, build_linux_aarch64]
+    needs: [build_linux_amd64]
     runs-on: ubuntu-latest
     steps:
          - uses: actions/download-artifact@v2
            with:
-             name: avail-apps-linux-amd64-build
-         - uses: actions/download-artifact@v2
-           with:
-             name: avail-apps-linux-aarch64-build
+             name: avail-explorer
          - name: Prepare
            id: prepare
            run: |
@@ -61,7 +41,7 @@ jobs:
            uses: svenstaro/upload-release-action@v2
            with:
              repo_token: ${{ secrets.PAT_TOKEN }}
-             file: /home/runner/work/avail-apps/avail-apps/avail-apps*
+             file: /home/runner/work/avail-apps/avail-apps/avail-explorer*
              release_name: ${{ steps.prepare.outputs.tag_name }}
              tag: ${{ steps.prepare.outputs.tag_name }}
              overwrite: true

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -61,7 +61,7 @@ jobs:
            uses: svenstaro/upload-release-action@v2
            with:
              repo_token: ${{ secrets.PAT_TOKEN }}
-             file: /home/runner/work/avail-light/avail-light/avail-apps*
+             file: /home/runner/work/avail-apps/avail-apps/avail-apps*
              release_name: ${{ steps.prepare.outputs.tag_name }}
              tag: ${{ steps.prepare.outputs.tag_name }}
              overwrite: true


### PR DESCRIPTION
**jira ticket:** 
https://polygon.atlassian.net/browse/DVT-121

**purpose:**
- provide automatic build / release pipeline for avail explorer artifacts, instead of having to build on remote hosts (devnets)
- all output binaries are compressed for fastest remote download

**tests:**
smoke tests, successful build action workflow run: https://github.com/maticnetwork/avail-apps/actions/runs/3161209787
